### PR TITLE
fix broken link at bottom of page

### DIFF
--- a/Home.md
+++ b/Home.md
@@ -156,4 +156,4 @@ Seymour articulates the goals for Logo the language.
 
 ![X.png](./images/X.png "X.png")
 
-[Seymour gives a lesson on Logo and Turtle Geometry.](https://logothings.wikispaces.com/An%20Introduction%20to%20Logo%20and%20Turtle%20Geometry)
+[Seymour gives a lesson on Logo and Turtle Geometry.](https://logothings.wikispaces.com/SeymourIntroduces.md)


### PR DESCRIPTION
The link to the "introduction to logo" page was broken.